### PR TITLE
Misc fixes for latest Verilator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ SRC_FILES := $(shell cat $(RTL_F))
 
 IVERILOG  := iverilog -g2012
 VERILATOR := verilator -Wall -Wno-PINCONNECTEMPTY -Wno-UNUSEDSIGNAL -Wno-UNUSEDPARAM --assert --timing
-VL_TRACE_FLAGS := --trace-fst --trace-structs --trace-params
+VL_TRACE_FLAGS := --trace-fst --trace-structs --trace-params --trace-max-array 8192 --trace-max-width 8192
 
 VL_DEFINES := +define+SIMULATION=1 +define+ASSERT=1 #+define+DEBUGON=1
 VL_WAIVER_OUT := --waiver-output new_waivers.txt

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,11 @@ INC_DIR   := src/rtl/include/
 SRC_DIR   := src/rtl/
 LIB_DIR   := src/rtl/lib/
 
+TEST_NAME := branchy
+TEST_DIR  := tests/$(TEST_NAME)
+TEST_FILES := $(TEST_DIR)/test.ld $(TEST_DIR)/test.s
+TEST_PRE   := $(TEST_DIR)/test.pre
+
 RTL_F := src/rtl.f
 
 INC_FILES := $(wildcard $(INC_DIR)/*.sv)
@@ -20,9 +25,12 @@ SIM_FLAGS :=
 Vtop: verilated
 	make -C obj_dir -f Vtop.mk Vtop  -j 8
 
+$(TEST_PRE): $(TEST_FILES)
+	make -C $(TEST_DIR) -f Makefile
+
 .PHONY: run
-run: Vtop
-	obj_dir/Vtop +load_disasm +preload:tests/branchy/test.pre +boot_vector:0000000080000000 ${SIM_FLAGS} | tee run.log
+run: Vtop $(TEST_PRE)
+	obj_dir/Vtop +load_disasm +preload:$(TEST_DIR)/test.pre +boot_vector:0000000080000000 ${SIM_FLAGS} | tee run.log
 	#obj_dir/Vtop +load_disasm +preload:tests/hello_ebreak.preload +boot_vector:0000000080000000 ${SIM_FLAGS} | tee run.log
 	#obj_dir/Vtop +load_disasm +preload:tests/hello.preload +boot_vector:0000000080000000 ${SIM_FLAGS} | tee run.log
 	#obj_dir/Vtop +load_disasm +preload:tests/start.preload +boot_vector:0000000080000000 ${SIM_FLAGS} | tee run.log

--- a/src/rtl/fe/fe_buf.sv
+++ b/src/rtl/fe/fe_buf.sv
@@ -31,7 +31,7 @@ localparam NUM_ENTS = FE_FB_NUM_ENTS;
 //
 
 typedef logic[FE_FB_SET_BITS-1:0] t_setid;
-function t_setid get_setid(t_paddr pa);
+function automatic t_setid get_setid(t_paddr pa);
     get_setid = pa[FE_FB_SET_MSB:FE_FB_SET_LSB];
 endfunction
 
@@ -93,9 +93,12 @@ always_comb fe_req_mis_fb0 = fe_fb_req_fb0.valid & ~fe_req_hit_fb0;
 
 // Update FBUF on IC rsp
 
+t_fe_fb_static rsp_ent;
+t_setid setid_fb1;
+always_comb rsp_ent = e_static_nnn[ic_fb_rsp_nnn.id[FE_FB_NUM_ENTS_LG2-1:0]];
+always_comb setid_fb1 = get_setid(rsp_ent.req.addr);
+
 always_ff @(posedge clk) begin
-    t_fe_fb_static rsp_ent = e_static_nnn[ic_fb_rsp_nnn.id[FE_FB_NUM_ENTS_LG2-1:0]];
-    automatic t_setid setid_fb1 = get_setid(rsp_ent.req.addr);
     if (ic_fb_rsp_nnn.valid & ~rsp_ent.pf) begin
         FBUF[setid_fb1].data    <= ic_fb_rsp_nnn.data.flat;
         FBUF[setid_fb1].valid   <= 1'b1;

--- a/src/rtl/include/common.pkg
+++ b/src/rtl/include/common.pkg
@@ -196,7 +196,7 @@ package common;
         t_byte [CL_SZ_BYTES-1:0]  B;
         t_hword[CL_SZ_HWORDS-1:0] H;
         t_word [CL_SZ_WORDS-1:0]  W;
-        t_word [CL_SZ_DWORDS-1:0] D;
+        t_dword [CL_SZ_DWORDS-1:0] D;
         logic[CL_SZ-1:0]       flat;
     } t_cl;
 

--- a/src/rtl/include/instr_decode.pkg
+++ b/src/rtl/include/instr_decode.pkg
@@ -214,18 +214,18 @@ package instr_decode;
         endcase
     endfunction
 
-    function automatic t_uop rv_instr_to_uop (t_rv_instr instr);
-        t_rv_instr_format ifmt = get_instr_format(instr.opcode);
+    function automatic t_uop rv_instr_to_uop (t_rv_instr rv_instr);
+        t_rv_instr_format ifmt = get_instr_format(rv_instr.opcode);
         rv_instr_to_uop = U_INVALID;
         unique casez (ifmt)
             RV_FMT_R: begin
                 // opcode = RV_OP_ALU_R
-                t_rv_alu_op_funct3     alu_op     = t_rv_alu_op_funct3'(instr.d.R.funct3);
-                t_rv_muldiv_op_funct3  muldiv_op  = t_rv_muldiv_op_funct3'(instr.d.R.funct3);
-                t_rv_muldivw_op_funct3 muldivw_op = t_rv_muldivw_op_funct3'(instr.d.R.funct3);
-                unique casez(instr.opcode)
+                t_rv_alu_op_funct3     alu_op     = t_rv_alu_op_funct3'(rv_instr.d.R.funct3);
+                t_rv_muldiv_op_funct3  muldiv_op  = t_rv_muldiv_op_funct3'(rv_instr.d.R.funct3);
+                t_rv_muldivw_op_funct3 muldivw_op = t_rv_muldivw_op_funct3'(rv_instr.d.R.funct3);
+                unique casez(rv_instr.opcode)
                     RV_OP_ALU0_R:
-                        unique casez({instr.d.R.funct7,alu_op})
+                        unique casez({rv_instr.d.R.funct7,alu_op})
                             {7'b0000000,ALU_ADD}:       rv_instr_to_uop = U_ADD;
                             {7'b0100000,ALU_ADD}:       rv_instr_to_uop = U_SUB;
                             {7'b0000000,ALU_SHL}:       rv_instr_to_uop = U_SLL;
@@ -247,7 +247,7 @@ package instr_decode;
                             default:  rv_instr_to_uop = U_INVALID;
                         endcase
                     RV_OP_ALU1_R:
-                        unique casez({instr.d.R.funct7,alu_op})
+                        unique casez({rv_instr.d.R.funct7,alu_op})
                             {7'b0000000,ALU_ADD}:       rv_instr_to_uop = U_ADDW;
                             {7'b0100000,ALU_ADD}:       rv_instr_to_uop = U_SUBW;
                             {7'b0000000,ALU_SHL}:       rv_instr_to_uop = U_SLLW;
@@ -266,43 +266,43 @@ package instr_decode;
 
             end
             RV_FMT_I: begin
-                unique casez(instr.opcode)
+                unique casez(rv_instr.opcode)
                     RV_OP_JALR  : rv_instr_to_uop = U_JALR;
                     RV_OP_LD    : begin
-                        //t_rv_ld_op_funct3 ld_op = t_rv_ld_op_funct3'(instr.d.I.funct3);
+                        //t_rv_ld_op_funct3 ld_op = t_rv_ld_op_funct3'(rv_instr.d.I.funct3);
                         rv_instr_to_uop = U_LOAD;
                     end
                     RV_OP_ST    : begin
-                        //t_rv_st_op_funct3 st_op = t_rv_st_op_funct3'(instr.d.I.funct3);
+                        //t_rv_st_op_funct3 st_op = t_rv_st_op_funct3'(rv_instr.d.I.funct3);
                         rv_instr_to_uop = U_STORE;
                     end
                     RV_OP_ALU0_I : begin
-                        t_rv_alu_op_funct3 alu_op = t_rv_alu_op_funct3'(instr.d.R.funct3);
+                        t_rv_alu_op_funct3 alu_op = t_rv_alu_op_funct3'(rv_instr.d.R.funct3);
                         unique casez(alu_op)
                             ALU_ADD:  rv_instr_to_uop = U_ADD;
                             ALU_SHL:  rv_instr_to_uop = U_SLL;
                             ALU_SLT:  rv_instr_to_uop = U_SLT;
                             ALU_SLTU: rv_instr_to_uop = U_SLTU;
                             ALU_XOR:  rv_instr_to_uop = U_XOR;
-                            ALU_SHR:  rv_instr_to_uop = instr.d.R.funct7[5] ? U_SRA : U_SRL; // same as R-type decode
+                            ALU_SHR:  rv_instr_to_uop = rv_instr.d.R.funct7[5] ? U_SRA : U_SRL; // same as R-type decode
                             ALU_OR:   rv_instr_to_uop = U_OR;
                             ALU_AND:  rv_instr_to_uop = U_AND;
                         endcase
                     end
                     RV_OP_ALU1_I : begin
-                        t_rv_alu_op_funct3 alu_op = t_rv_alu_op_funct3'(instr.d.R.funct3);
+                        t_rv_alu_op_funct3 alu_op = t_rv_alu_op_funct3'(rv_instr.d.R.funct3);
                         unique casez(alu_op)
                             ALU_ADD:  rv_instr_to_uop = U_ADDW;
                             ALU_SHL:  rv_instr_to_uop = U_SLLW;
-                            ALU_SHR:  rv_instr_to_uop = instr.d.R.funct7[5] ? U_SRAW : U_SRLW; // same as R-type decode
+                            ALU_SHR:  rv_instr_to_uop = rv_instr.d.R.funct7[5] ? U_SRAW : U_SRLW; // same as R-type decode
                             default:  rv_instr_to_uop = U_INVALID;
                         endcase
                     end
                     RV_OP_FENCE : rv_instr_to_uop = U_INVALID;
                     RV_OP_SYSTEM: begin
-                        t_rv_sys_op_funct3 sys_op = t_rv_sys_op_funct3'(instr.d.I.funct3);
+                        t_rv_sys_op_funct3 sys_op = t_rv_sys_op_funct3'(rv_instr.d.I.funct3);
                         unique casez(sys_op)
-                            RV_SYS_ECALL_EBREAK: rv_instr_to_uop = instr.d.I.imm_11_0[0] ? U_EBREAK : U_ECALL;
+                            RV_SYS_ECALL_EBREAK: rv_instr_to_uop = rv_instr.d.I.imm_11_0[0] ? U_EBREAK : U_ECALL;
                             RV_SYS_CSRRW:        rv_instr_to_uop = U_CSRRW;
                             RV_SYS_CSRRS:        rv_instr_to_uop = U_CSRRS;
                             RV_SYS_CSRRC:        rv_instr_to_uop = U_CSRRC;
@@ -316,32 +316,32 @@ package instr_decode;
                 endcase
             end
             RV_FMT_J: begin
-                unique casez(instr.opcode)
+                unique casez(rv_instr.opcode)
                     RV_OP_JAL: rv_instr_to_uop = U_JAL;
                     default:   rv_instr_to_uop = U_INVALID;
                 endcase
             end
             RV_FMT_U: begin
                 // opcode = RV_OP_ALU_R
-                unique casez(instr.opcode)
+                unique casez(rv_instr.opcode)
                     RV_OP_LUI:   rv_instr_to_uop = U_LUI;
                     RV_OP_AUIPC: rv_instr_to_uop = U_AUIPC;
                     default:     rv_instr_to_uop = U_INVALID;
                 endcase
             end
             RV_FMT_S: begin
-                unique casez(instr.opcode)
+                unique casez(rv_instr.opcode)
                     RV_OP_ST    : begin
-                        //t_rv_st_op_funct3 st_op = t_rv_st_op_funct3'(instr.d.I.funct3);
+                        //t_rv_st_op_funct3 st_op = t_rv_st_op_funct3'(rv_instr.d.I.funct3);
                         rv_instr_to_uop = U_STORE;
                     end
                     default:     rv_instr_to_uop = U_INVALID;
                 endcase
             end
             RV_FMT_B: begin
-                unique casez(instr.opcode)
+                unique casez(rv_instr.opcode)
                     RV_OP_BR: begin
-                        t_rv_br_op_funct3 br_op = t_rv_br_op_funct3'(instr.d.B.funct3);
+                        t_rv_br_op_funct3 br_op = t_rv_br_op_funct3'(rv_instr.d.B.funct3);
                         unique casez(br_op)
                             RV_BR_BEQ:  rv_instr_to_uop = U_BR_EQ;
                             RV_BR_BNE:  rv_instr_to_uop = U_BR_NE;

--- a/src/rtl/rename/prf.sv
+++ b/src/rtl/rename/prf.sv
@@ -39,6 +39,7 @@ module prf
     `ifdef SIMULATION
     input  t_simid       simid_rn0_inst,
     input  t_simid       simid_rd0_inst,
+    input  t_simid       simid_rd1_inst,
     `endif
     output t_prf_id      pdst_rn1,
     output t_prf_id      pdst_old_rn1
@@ -210,7 +211,7 @@ always @(posedge clk) begin
 
     for (int r=0; r<NUM_MAP_READS; r++) begin
         if (rdmap_nq_rd1[r]) begin
-            `UINFO(simid_rd0_inst, ("unit:RN func:rat_read gpr_id:%s psrc:%s psrc_pend:%0d", f_describe_gpr_addr(rdmap_gpr_rd1_inst[r]), f_describe_prf(rdmap_psrc_rd1[r]), rdmap_pend_rd1[r]))
+            `UINFO(simid_rd1_inst, ("unit:RN func:rat_read gpr_id:%s psrc:%s psrc_pend:%0d", f_describe_gpr_addr(rdmap_gpr_rd1_inst[r]), f_describe_prf(rdmap_psrc_rd1[r]), rdmap_pend_rd1[r]))
         end
     end
 

--- a/src/rtl/rename/rename.sv
+++ b/src/rtl/rename/rename.sv
@@ -97,6 +97,7 @@ prf #(.NUM_ENTRIES(IPRF_NUM_ENTS), .NUM_REG_READS(IPRF_NUM_READS), .NUM_REG_WRIT
     `ifdef SIMULATION
     .simid_rn0_inst ( uinstr_rn0.SIMID ) ,
     .simid_rd0_inst ( uinstr_rn0.SIMID ) ,
+    .simid_rd1_inst ( uinstr_rn1.SIMID ) ,
     `endif
     .rename_ready_rn0 ( rename_ready_prf_rn0 ) ,
 

--- a/src/rtl/sim/cache_sim.pkg
+++ b/src/rtl/sim/cache_sim.pkg
@@ -42,7 +42,7 @@ endfunction
     ////////////////////////
 
 task f_wr_l2data_byte_blkng(t_byte b, t_paddr byte_addr);
-    top.core.l2.MEMORY[byte_addr] <= b;
+    top.core.l2.MEMORY[byte_addr] = b;
 endtask
 
 function automatic void f_wr_l2data_byte(t_byte b, t_paddr byte_addr);


### PR DESCRIPTION
Fixes a few warnings and compile errors that popped out when trying to run with Verilator 5.044

Still runs "branchy", "fib", & other tests just fine as far as I can tell.